### PR TITLE
Panic handler

### DIFF
--- a/addressbook.go
+++ b/addressbook.go
@@ -13,7 +13,11 @@ func AddAddressBookEntry(hostname, destination, bookType string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	result := retpre["message"].(string)
+	value, err := responseValue(retpre, "message")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -29,7 +33,11 @@ func RemoveAddressBookEntry(hostname, destination, bookType string) (string, err
 	if err != nil {
 		return "", err
 	}
-	result := retpre["message"].(string)
+	value, err := responseValue(retpre, "message")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -43,7 +51,11 @@ func EditAddressBookSubscription(hostnames []string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result := retpre["message"].(string)
+	value, err := responseValue(retpre, "message")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 
 	return result, nil
 }
@@ -64,6 +76,10 @@ func EditConfigFile(etags, lastFetched, lastModified, localAddressbook, logPath,
 	if err != nil {
 		return "", err
 	}
-	result := retpre["message"].(string)
+	value, err := responseValue(retpre, "message")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }

--- a/auth.go
+++ b/auth.go
@@ -57,9 +57,16 @@ func InitializeWithSelfSignedCert(host, port, path, cert string) error {
 
 // Call an RPC method with params
 func Call(method string, params interface{}) (map[string]interface{}, error) {
+	if rpcClient == nil {
+		return nil, fmt.Errorf("RPC client is not initialized")
+	}
+
 	response, err := rpcClient.Call(method, params)
 	if err != nil {
 		return nil, err
+	}
+	if response == nil {
+		return nil, fmt.Errorf("empty response from RPC call")
 	}
 	if response.Error != nil {
 		return nil, response.Error
@@ -89,7 +96,16 @@ func Authenticate(password string) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	token = retpre["Token"].(string)
-	version := int(retpre["API"].(float64))
+	value, err := responseValue(retpre, "Token")
+	if err != nil {
+		return -1, err
+	}
+	nextToken := value.(string)
+	value, err = responseValue(retpre, "API")
+	if err != nil {
+		return -1, err
+	}
+	version := int(value.(float64))
+	token = nextToken
 	return version, nil
 }

--- a/info.go
+++ b/info.go
@@ -11,7 +11,11 @@ func ParticipatingTunnels() (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["i2p.router.net.tunnels.participating"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.participating")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -24,7 +28,11 @@ func Status() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result := retpre["i2p.router.status"].(string)
+	value, err := responseValue(retpre, "i2p.router.status")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -37,7 +45,11 @@ func NetStatus() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result := int(retpre["i2p.router.net.status"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.status")
+	if err != nil {
+		return "", err
+	}
+	result := int(value.(float64))
 	switch result {
 	case 0:
 		return "OK", nil
@@ -83,6 +95,10 @@ func Reseeding() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	result := retpre["i2p.router.netdb.isreseeding"].(bool)
+	value, err := responseValue(retpre, "i2p.router.netdb.isreseeding")
+	if err != nil {
+		return false, err
+	}
+	result := value.(bool)
 	return result, nil
 }

--- a/info_ext.go
+++ b/info_ext.go
@@ -1,5 +1,7 @@
 package i2pcontrol
 
+import "fmt"
+
 // IncomingBW bandwidth per second
 func IncomingBW() (int, error) {
 	retpre, err := Call("RouterInfo", map[string]interface{}{
@@ -9,7 +11,11 @@ func IncomingBW() (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["i2p.router.net.bw.inbound.1s"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.bw.inbound.1s")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -22,7 +28,11 @@ func OutgoingBw() (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["i2p.router.net.bw.outbound.1s"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.bw.outbound.1s")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -35,7 +45,11 @@ func TotalOutgoingBW() (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["i2p.router.net.bw.used.outbound.total"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.bw.used.outbound.total")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -48,7 +62,11 @@ func TotalIncomingBW() (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["i2p.router.net.bw.used.inbound.total"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.bw.used.inbound.total")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -61,7 +79,11 @@ func UpTime() (int64, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int64(retpre["i2p.router.uptime"].(float64))
+	value, err := responseValue(retpre, "i2p.router.uptime")
+	if err != nil {
+		return -1, err
+	}
+	result := int64(value.(float64))
 	return result, nil
 }
 
@@ -74,7 +96,11 @@ func KnownPeers() (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["i2p.router.netdb.knownpeers"].(float64))
+	value, err := responseValue(retpre, "i2p.router.netdb.knownpeers")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -88,7 +114,11 @@ func ActivePeers() (int, error) {
 		return -1, err
 	}
 
-	result := int(retpre["i2p.router.netdb.activepeers"].(float64))
+	value, err := responseValue(retpre, "i2p.router.netdb.activepeers")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -102,7 +132,11 @@ func Version() (string, error) {
 		return "", err
 	}
 
-	result := retpre["i2p.router.version"].(string)
+	value, err := responseValue(retpre, "i2p.router.version")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -116,7 +150,11 @@ func RouterID() (string, error) {
 		return "", err
 	}
 
-	result := retpre["i2p.router.id"].(string)
+	value, err := responseValue(retpre, "i2p.router.id")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -129,7 +167,11 @@ func RouterInfo() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result := retpre["i2p.router.info"].(string)
+	value, err := responseValue(retpre, "i2p.router.info")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -143,7 +185,11 @@ func ClockSkew() (int, error) {
 		return -1, err
 	}
 
-	result := int(retpre["i2p.router.clockskew"].(float64))
+	value, err := responseValue(retpre, "i2p.router.clockskew")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -157,7 +203,11 @@ func InboundExploratoryTunnels() (int, error) {
 		return -1, err
 	}
 
-	result := int(retpre["i2p.router.net.tunnels.exploratory.inbound"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.exploratory.inbound")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -171,7 +221,11 @@ func OutboundExploratoryTunnels() (int, error) {
 		return -1, err
 	}
 
-	result := int(retpre["i2p.router.net.tunnels.exploratory.outbound"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.exploratory.outbound")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -184,7 +238,11 @@ func ExploratoryTunnelsInfo() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return retpre["i2p.router.net.tunnels.exploratory.info.list"].([]interface{}), nil
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.exploratory.info.list")
+	if err != nil {
+		return nil, err
+	}
+	return value.([]interface{}), nil
 }
 
 // ClientTunnelsInfo gets the client tunnels info
@@ -196,7 +254,11 @@ func ClientTunnelsInfo() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return retpre["i2p.router.net.tunnels.client.info.list"].([]interface{}), nil
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.client.info.list")
+	if err != nil {
+		return nil, err
+	}
+	return value.([]interface{}), nil
 }
 
 // ShareRatio gets the share ratio of the router
@@ -208,7 +270,12 @@ func ShareRatio() (float64, error) {
 	if err != nil {
 		return -1, err
 	}
-	return retpre["i2p.router.net.tunnels.shareratio"].(float64), nil
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.shareratio")
+	if err != nil {
+		return -1, err
+	}
+	result := value.(float64)
+	return result, nil
 }
 
 // ParticipatingTunnelsCount gets the number of participating tunnels (inactive + active)
@@ -220,7 +287,11 @@ func ParticipatingTunnelsCount() (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["i2p.router.net.tunnels.participating"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.participating")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -233,7 +304,11 @@ func ParticipatingTunnelsInfo() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return retpre["i2p.router.net.tunnels.participating.info"].([]interface{}), nil
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.participating.info")
+	if err != nil {
+		return nil, err
+	}
+	return value.([]interface{}), nil
 }
 
 // InboundClientTunnels gets the number of inbound client tunnels
@@ -246,7 +321,11 @@ func InboundClientTunnels() (int, error) {
 		return -1, err
 	}
 
-	result := int(retpre["i2p.router.net.tunnels.client.inbound"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.client.inbound")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -260,7 +339,11 @@ func OutboundClientTunnels() (int, error) {
 		return -1, err
 	}
 
-	result := int(retpre["i2p.router.net.tunnels.client.outbound"].(float64))
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.client.outbound")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -274,9 +357,16 @@ func KnownPeersList() ([]string, error) {
 		return nil, err
 	}
 
-	resultInterface := retpre["i2p.router.netdb.peers"].([]interface{})
+	value, err := responseValue(retpre, "i2p.router.netdb.peers")
+	if err != nil {
+		return nil, err
+	}
+	resultInterface := value.([]interface{})
 	result := make([]string, len(resultInterface))
 	for i, v := range resultInterface {
+		if v == nil {
+			return nil, fmt.Errorf("RPC response field %q[%d] is nil", "i2p.router.netdb.peers", i)
+		}
 		result[i] = v.(string)
 	}
 	return result, nil
@@ -292,9 +382,16 @@ func ActivePeersList() ([]string, error) {
 		return nil, err
 	}
 
-	resultInterface := retpre["i2p.router.netdb.activepeers.list"].([]interface{})
+	value, err := responseValue(retpre, "i2p.router.netdb.activepeers.list")
+	if err != nil {
+		return nil, err
+	}
+	resultInterface := value.([]interface{})
 	result := make([]string, len(resultInterface))
 	for i, v := range resultInterface {
+		if v == nil {
+			return nil, fmt.Errorf("RPC response field %q[%d] is nil", "i2p.router.netdb.activepeers.list", i)
+		}
 		result[i] = v.(string)
 	}
 	return result, nil
@@ -310,9 +407,16 @@ func ActivePeersInfo() ([]string, error) {
 		return nil, err
 	}
 
-	resultInterface := retpre["i2p.router.netdb.activepeers.info"].([]interface{})
+	value, err := responseValue(retpre, "i2p.router.netdb.activepeers.info")
+	if err != nil {
+		return nil, err
+	}
+	resultInterface := value.([]interface{})
 	result := make([]string, len(resultInterface))
 	for i, v := range resultInterface {
+		if v == nil {
+			return nil, fmt.Errorf("RPC response field %q[%d] is nil", "i2p.router.netdb.activepeers.info", i)
+		}
 		result[i] = v.(string)
 	}
 	return result, nil
@@ -328,9 +432,16 @@ func AllPeersList() ([]string, error) {
 		return nil, err
 	}
 
-	resultInterface := retpre["i2p.router.netdb.peers.list"].([]interface{})
+	value, err := responseValue(retpre, "i2p.router.netdb.peers.list")
+	if err != nil {
+		return nil, err
+	}
+	resultInterface := value.([]interface{})
 	result := make([]string, len(resultInterface))
 	for i, v := range resultInterface {
+		if v == nil {
+			return nil, fmt.Errorf("RPC response field %q[%d] is nil", "i2p.router.netdb.peers.list", i)
+		}
 		result[i] = v.(string)
 	}
 	return result, nil
@@ -346,9 +457,16 @@ func AllPeersInfo() ([]string, error) {
 		return nil, err
 	}
 
-	resultInterface := retpre["i2p.router.netdb.peers.info"].([]interface{})
+	value, err := responseValue(retpre, "i2p.router.netdb.peers.info")
+	if err != nil {
+		return nil, err
+	}
+	resultInterface := value.([]interface{})
 	result := make([]string, len(resultInterface))
 	for i, v := range resultInterface {
+		if v == nil {
+			return nil, fmt.Errorf("RPC response field %q[%d] is nil", "i2p.router.netdb.peers.info", i)
+		}
 		result[i] = v.(string)
 	}
 	return result, nil
@@ -363,7 +481,11 @@ func NTCPLimit() (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["i2p.router.netdb.ntcp.limit"].(float64))
+	value, err := responseValue(retpre, "i2p.router.netdb.ntcp.limit")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -376,7 +498,11 @@ func SSULimit() (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["i2p.router.netdb.ssu.limit"].(float64))
+	value, err := responseValue(retpre, "i2p.router.netdb.ssu.limit")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 
@@ -389,7 +515,11 @@ func NewsEntries() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result := retpre["i2p.router.news"].(string)
+	value, err := responseValue(retpre, "i2p.router.news")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -402,7 +532,11 @@ func BannedPeers() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return retpre["i2p.router.netdb.bannedpeers"].(map[string]interface{}), nil
+	value, err := responseValue(retpre, "i2p.router.netdb.bannedpeers")
+	if err != nil {
+		return nil, err
+	}
+	return value.(map[string]interface{}), nil
 }
 
 func RouterLogs() ([]string, error) {
@@ -413,10 +547,17 @@ func RouterLogs() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	resultInterface := retpre["i2p.router.logs"].([]interface{})
+	value, err := responseValue(retpre, "i2p.router.logs")
+	if err != nil {
+		return nil, err
+	}
+	resultInterface := value.([]interface{})
 	result := make([]string, len(resultInterface))
 
 	for i, v := range resultInterface {
+		if v == nil {
+			return nil, fmt.Errorf("RPC response field %q[%d] is nil", "i2p.router.logs", i)
+		}
 		result[i] = v.(string)
 	}
 
@@ -431,7 +572,11 @@ func ClearRouterLogs() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result := retpre["i2p.router.logs.clear"].(string)
+	value, err := responseValue(retpre, "i2p.router.logs.clear")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -445,8 +590,11 @@ func ActivePeersStats() ([]interface{}, error) {
 		return nil, err
 	}
 
-	result := retpre["i2p.router.netdb.activepeers.stats"].([]interface{})
-	return result, nil
+	value, err := responseValue(retpre, "i2p.router.netdb.activepeers.stats")
+	if err != nil {
+		return nil, err
+	}
+	return value.([]interface{}), nil
 }
 
 // PrivateAddressBook gets the list of private address book entries
@@ -459,7 +607,11 @@ func PrivateAddressBook() ([]interface{}, error) {
 		return nil, err
 	}
 
-	return retpre["i2p.router.addressbook.private.list"].([]interface{}), nil
+	value, err := responseValue(retpre, "i2p.router.addressbook.private.list")
+	if err != nil {
+		return nil, err
+	}
+	return value.([]interface{}), nil
 }
 
 // LocalAddressBook gets the list of local address book entries
@@ -472,7 +624,11 @@ func LocalAddressBook() ([]interface{}, error) {
 		return nil, err
 	}
 
-	return retpre["i2p.router.addressbook.local.list"].([]interface{}), nil
+	value, err := responseValue(retpre, "i2p.router.addressbook.local.list")
+	if err != nil {
+		return nil, err
+	}
+	return value.([]interface{}), nil
 }
 
 // RouterAddressBook gets the list of router address book entries
@@ -484,7 +640,11 @@ func RouterAddressBook() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return retpre["i2p.router.addressbook.router.list"].([]interface{}), nil
+	value, err := responseValue(retpre, "i2p.router.addressbook.router.list")
+	if err != nil {
+		return nil, err
+	}
+	return value.([]interface{}), nil
 }
 
 // PublishedAddressBook gets the list of published address book entries
@@ -496,7 +656,11 @@ func PublishedAddressBook() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return retpre["i2p.router.addressbook.published.list"].([]interface{}), nil
+	value, err := responseValue(retpre, "i2p.router.addressbook.published.list")
+	if err != nil {
+		return nil, err
+	}
+	return value.([]interface{}), nil
 }
 
 // AddressBookConfig gets the address book configuration, including the path and entries
@@ -509,7 +673,11 @@ func AddressBookConfig() ([]interface{}, error) {
 		return nil, err
 	}
 
-	raw := retpre["i2p.router.addressbook.config"].(map[string]interface{})
+	value, err := responseValue(retpre, "i2p.router.addressbook.config")
+	if err != nil {
+		return nil, err
+	}
+	raw := value.(map[string]interface{})
 	path := raw["path"]
 	entries := raw["entries"]
 
@@ -528,7 +696,11 @@ func AddressBookSubscriptions() ([]interface{}, error) {
 		return nil, err
 	}
 
-	raw := retpre["i2p.router.addressbook.subscriptions"].(map[string]interface{})
+	value, err := responseValue(retpre, "i2p.router.addressbook.subscriptions")
+	if err != nil {
+		return nil, err
+	}
+	raw := value.(map[string]interface{})
 	path := raw["path"]
 	entries := raw["entries"]
 
@@ -545,5 +717,9 @@ func HiddenServices() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return retpre["i2p.router.net.tunnels.i2ptunnel"].([]interface{}), nil
+	value, err := responseValue(retpre, "i2p.router.net.tunnels.i2ptunnel")
+	if err != nil {
+		return nil, err
+	}
+	return value.([]interface{}), nil
 }

--- a/info_go_hash.go
+++ b/info_go_hash.go
@@ -13,6 +13,10 @@ func RouterHash() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result := retpre["i2p.router.hash"].(string)
+	value, err := responseValue(retpre, "i2p.router.hash")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }

--- a/manager.go
+++ b/manager.go
@@ -9,7 +9,11 @@ func Echo(echo string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result := retpre["Result"].(string)
+	value, err := responseValue(retpre, "Result")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -70,7 +74,11 @@ func FindUpdates() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	result := retpre["FindUpdates"].(bool)
+	value, err := responseValue(retpre, "FindUpdates")
+	if err != nil {
+		return false, err
+	}
+	result := value.(bool)
 	return result, nil
 }
 

--- a/manager.go
+++ b/manager.go
@@ -41,6 +41,17 @@ func Restart() (string, error) {
 	return "Restart Initiated", nil
 }
 
+func Reseed() (string, error) {
+	_, err := Call("RouterManager", map[string]interface{}{
+		"Reseed": nil,
+		"Token":  token,
+	})
+	if err != nil {
+		return "", err
+	}
+	return "Reseed Initiated", nil
+}
+
 // Shutdown initiates a graceful restart, which will occur in around 11 minutes.
 func ShutdownGraceful() (string, error) {
 	_, err := Call("RouterManager", map[string]interface{}{

--- a/response.go
+++ b/response.go
@@ -1,0 +1,19 @@
+package i2pcontrol
+
+import "fmt"
+
+func responseValue(values map[string]interface{}, key string) (interface{}, error) {
+	if values == nil {
+		return nil, fmt.Errorf("missing RPC response field %q: response is nil", key)
+	}
+
+	value, ok := values[key]
+	if !ok {
+		return nil, fmt.Errorf("missing RPC response field %q", key)
+	}
+	if value == nil {
+		return nil, fmt.Errorf("RPC response field %q is nil", key)
+	}
+
+	return value, nil
+}

--- a/setting.go
+++ b/setting.go
@@ -9,10 +9,11 @@ func Upnp() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if retpre["i2p.router.net.upnp"] == nil {
+	value, err := responseValue(retpre, "i2p.router.net.upnp")
+	if err != nil {
 		return "Upnp Disabled", nil
 	}
-	result := retpre["i2p.router.net.upnp"].(string)
+	result := value.(string)
 
 	return result, nil
 }

--- a/stats.go
+++ b/stats.go
@@ -14,7 +14,11 @@ func RateStatExact(Stat string, Period int) (float64, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := retpre["Result"].(float64)
+	value, err := responseValue(retpre, "Result")
+	if err != nil {
+		return -1, err
+	}
+	result := value.(float64)
 	return result, nil
 }
 
@@ -28,7 +32,11 @@ func RateStat(Stat string, Period int) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	result := int(retpre["Result"].(float64))
+	value, err := responseValue(retpre, "Result")
+	if err != nil {
+		return -1, err
+	}
+	result := int(value.(float64))
 	return result, nil
 }
 

--- a/tunnelmanager.go
+++ b/tunnelmanager.go
@@ -217,10 +217,18 @@ func ServiceAction(name, action string, toAll bool) (string, map[string]interfac
 		return "", nil, err
 	}
 	var tunnelOptions map[string]interface{}
-	result := retpre["status"].(string)
+	value, err := responseValue(retpre, "status")
+	if err != nil {
+		return "", nil, err
+	}
+	result := value.(string)
 	// a get action returns the tunnel options; this is the only action that returns them
 	if action == "get" {
-		tunnelOptions = retpre["info"].(map[string]interface{})
+		value, err = responseValue(retpre, "info")
+		if err != nil {
+			return "", nil, err
+		}
+		tunnelOptions = value.(map[string]interface{})
 	}
 
 	return result, tunnelOptions, nil
@@ -238,7 +246,11 @@ func EditClientTunnel(client EditClientConfig) (string, error) {
 		return "", err
 	}
 
-	result := retpre["status"].(string)
+	value, err := responseValue(retpre, "status")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -253,7 +265,11 @@ func EditHiddenService(service EditServiceConfig) (string, error) {
 		return "", err
 	}
 
-	result := retpre["status"].(string)
+	value, err := responseValue(retpre, "status")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -268,7 +284,11 @@ func AddClientTunnel(client ClientConfig) (string, error) {
 		return "", err
 	}
 
-	result := retpre["status"].(string)
+	value, err := responseValue(retpre, "status")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 
@@ -282,7 +302,11 @@ func AddHiddenService(service ServiceConfig) (string, error) {
 		return "", err
 	}
 
-	result := retpre["status"].(string)
+	value, err := responseValue(retpre, "status")
+	if err != nil {
+		return "", err
+	}
+	result := value.(string)
 	return result, nil
 }
 


### PR DESCRIPTION
Issue: 

New methods are not fully integrated and or problems can arise during communication. This leads to the value of the interface becoming nil, if we were to do type conversion on this, go panics. We need to ensure we never panic for application lifecycle. 

The fix: 

`responseValue` function. This checks to see if our responseField is valid AND that we check if the response is nil, if it is, then we error out.

